### PR TITLE
[UPDATE] Ignored a silly rule from flake8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,3 +2,4 @@
 max-line-length=120
 application_import_names=bot
 exclude=.venv
+ignore=B311


### PR DESCRIPTION
This rule basically said that we cannot use the random module as it is insecure for cryptography, which we are not even using it for. This commit ignores this so the random module can be used. Please merge this ASAP.